### PR TITLE
add `HookReturnCode` to error message

### DIFF
--- a/src/Xrpld.ts
+++ b/src/Xrpld.ts
@@ -40,7 +40,9 @@ export class Xrpld {
         txResponse?.result?.meta as TransactionMetadata
       )
       if (hookExecutions.executions.length === 1) {
-        throw Error(hookExecutions.executions[0].HookReturnString)
+        throw Error(
+          `${hookExecutions.executions[0].HookReturnCode}: ${hookExecutions.executions[0].HookReturnString}`
+        )
       }
       throw Error(JSON.stringify(hookExecutions.executions))
     }


### PR DESCRIPTION
## High Level Overview of Change

Fixed to output not only `HookReturnString` but also `HookReturnCode` when a Hook fails with `tecHOOK_REJECTED`.