### PR TITLE
Write logger output directly to stdout

### DIFF
--- a/src/libs/logger/index.ts
+++ b/src/libs/logger/index.ts
@@ -3,5 +3,5 @@ import winston, { createLogger } from 'winston'
 export const appLogger = createLogger({
   level: process.env.LOG_LEVEL || 'info',
   format: winston.format.simple(),
-  transports: [new winston.transports.Console()],
+  transports: [new winston.transports.Stream({ stream: process.stdout })],
 })


### PR DESCRIPTION
## High Level Overview of Change

### Summary

- Replace the Winston console transport with a stream transport that writes directly to stdout.
- Keep `appLogger.error(...)` on stdout while avoiding Jest's `console.log` wrapper output.

### Verification

- Confirmed `appLogger.error(...)` still writes to stdout.
- Confirmed the output format is limited to the logger message, without the extra `console.log` header and stack location.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->